### PR TITLE
fix relative path problem

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ var spawn = require('child_process').spawn;
 var out = fs.openSync('./phantomjs.log', 'w+');
 var err = fs.openSync('./phantomjs.log', 'w+');
 
-exports.path = './node_modules/phantomjs/bin/phantomjs';
+exports.path = require.resolve('phantomjs/bin/phantomjs');
 if(process.platform === 'win32') exports.path += 'exe';
 
 exports.version = '1.9.2';


### PR DESCRIPTION
When you require phantomjs-server it can't find the phantomjs binary because it's path is always relative to current working directory. I've changed it to use `require.resolve` which should be more robust.
