### PR TITLE
fix relative path problem for win32

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,9 @@ var out = fs.openSync('./phantomjs.log', 'w+');
 var err = fs.openSync('./phantomjs.log', 'w+');
 
 exports.path = require.resolve('phantomjs/bin/phantomjs');
-if(process.platform === 'win32') exports.path += 'exe';
+if(process.platform === 'win32') {
+  exports.path = require.resolve('phantomjs/lib/phantom/phantomjs.exe');
+}
 
 exports.version = '1.9.2';
 


### PR DESCRIPTION
Did a fix on the path of phantomjs on win32 platform.
